### PR TITLE
Code conforms to PEP 8

### DIFF
--- a/leveldb-client.py
+++ b/leveldb-client.py
@@ -6,6 +6,7 @@ import argparse
 import cmd
 from xmlrpclib import ServerProxy
 
+
 class Cmd(cmd.Cmd):
     def __init__(self, host, port, *args, **kw):
         cmd.Cmd.__init__(self, *args, **kw)
@@ -13,45 +14,47 @@ class Cmd(cmd.Cmd):
         self.server = ServerProxy('http://%s:%d' % (host, port))
 
     def do_put(self, arg):
-        args =  arg.split()
+        args = arg.split()
         if len(args) != 2:
-            print "(error) ERR wrong number of arguments for 'put' command"
+            print("(error) ERR wrong number of arguments for 'put' command")
             return
         key, value = args
 
         result = self.server.put(key, value)
 
     def do_get(self, arg):
-        args =  arg.split()
+        args = arg.split()
         if len(args) != 1:
-            print "(error) ERR wrong number of arguments for 'get' command"
+            print("(error) ERR wrong number of arguments for 'get' command")
             return
         key, = args
 
         result = self.server.get(key)
         if result:
-            print result
+            print(result)
 
     def do_delete(self, arg):
-        args =  arg.split()
+        args = arg.split()
         if len(args) != 1:
-            print "(error) ERR wrong number of arguments for 'delete' command"
+            print("(error) ERR wrong number of arguments for 'delete' command")
             return
         key, = args
 
         result = self.server.delete(key)
 
-    def do_EOF(self, arg):
+    def do_eof(self, arg):
         return True
+
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--host', type=str, nargs='?', default='localhost')
     parser.add_argument('--port', type=int, nargs='?', default=8000)
-    args =  parser.parse_args()
+    args = parser.parse_args()
 
-    cmd = Cmd(args.host, args.port)
-    cmd.cmdloop()
+    command = Cmd(args.host, args.port)
+    command.cmdloop()
+
 
 if __name__ == '__main__':
     main()

--- a/leveldb-server.py
+++ b/leveldb-server.py
@@ -6,8 +6,10 @@ from SimpleXMLRPCServer import SimpleXMLRPCServer, SimpleXMLRPCRequestHandler
 
 import leveldb
 
+
 class RequestHandler(SimpleXMLRPCRequestHandler):
     rpc_paths = ('/RPC2',)
+
 
 class LevelDBMethod(object):
     def __init__(self, datadir):
@@ -19,17 +21,18 @@ class LevelDBMethod(object):
     def get(self, key):
         try:
             return self.db.Get(key)
-        except KeyError, err:
+        except KeyError:
             return ''
 
     def delete(self, key):
         return self.db.Delete(key)
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--port', type=int, nargs='?', default=8000)
     parser.add_argument('--datadir', type=str, nargs='?', default='data')
-    args =  parser.parse_args()
+    args = parser.parse_args()
 
     # Create server
     server = SimpleXMLRPCServer(("localhost", args.port),
@@ -38,6 +41,7 @@ def main():
     server.register_introspection_functions()
     server.register_instance(LevelDBMethod(args.datadir))
     server.serve_forever()
+
 
 if __name__ == '__main__':
     main()

--- a/leveldb-server.py
+++ b/leveldb-server.py
@@ -1,6 +1,7 @@
 # vim: set fileencoding=utf8
 '''XML-RPC server for leveldb
 '''
+
 import argparse
 from SimpleXMLRPCServer import SimpleXMLRPCServer, SimpleXMLRPCRequestHandler
 


### PR DESCRIPTION
Code is now [PEP 8](https://pep8-ja.readthedocs.io/ja/latest/) compliant.
Nothing should break.
Also, is this code intended to run on Python2?
If not, you cannot use the syntax on line 22 of "leveldb-server.py" or line 18 of "leveldb-client.py".
If you are planning to run on Python2, we do not recommend it, as it is no longer supported.